### PR TITLE
Lab 2: Logowanie oraz biblioteki OpenSource - rozwiązanie

### DIFF
--- a/Python/Flask_Book_Library/project/customers/models.py
+++ b/Python/Flask_Book_Library/project/customers/models.py
@@ -22,7 +22,23 @@ class Customer(db.Model):
         print("Getting: " + str(self),flush=True)
 
     def __repr__(self):
-        return f"Customer(ID: {self.id}, Name: {self.name}, City: {self.city}, Age: {self.age}, Pesel: {self.pesel}, Street: {self.street}, AppNo: {self.appNo})"
+        #masked_name = Customer.data_masker(self.name)
+        masked_city = Customer.data_masker(self.city)
+        #masked_age = Customer.data_masker(self.age)
+        masked_pesel = Customer.data_masker(self.pesel)
+        masked_street = Customer.data_masker(self.street)
+        masked_appNo = Customer.data_masker(self.appNo)
+        #return f"Customer(ID: {self.id}, Name: {masked_name}, City: {masked_city}, Age: {masked_age}, Pesel: {masked_pesel}, Street: {masked_street}, AppNo: {masked_appNo})"
+        return f"Customer(ID: {self.id}, Name: {self.name}, City: {masked_city}, Age: {self.age}, Pesel: {masked_pesel}, Street: {masked_street}, AppNo: {masked_appNo})"
+
+    @staticmethod
+    def data_masker(data_to_be_masked):
+        mask_len = len(data_to_be_masked)
+        if mask_len == 0:
+            mask = '***********'
+        else:
+            mask = '*'*mask_len
+        return mask
 
 
 with app.app_context():


### PR DESCRIPTION
### Zadanie 1

Zadanie 1 dotyczy wykrycia oraz usunięcia wycieku danych wrażliwych do systemu logów aplikacji bibliotecznej. 

Dane wrażliwe zostały zidentyfikowane w logach dla akcji dodawania nowego użytkownika na podstronie 'customers'. Dane wyświetlane w logach to imię, wiek, numer PESEL adres. Wyciek informacji niejawnej nie został stwierdzony dla procedury aktualizacji danych istniejącego użytkownika. 

![Wyciek danych do logów](https://github.com/user-attachments/assets/92cd9c9a-08eb-4788-8e77-7a0946a35c3d)

Poprawka polega na dodaniu w pliku 'models.py' funkcji która przed stworzeniem logu dotyczącego powstania nowego użytkownika, zastąpi treść pól zawierających dane wrażliwe, korespondującym do ich długości, ciągiem znaków '*'. 

Dodatkowo została zaimplementowana obsługa maskowania pustego pola (w przypadku rozwoju aplikacji w kierunku zdjęcia wymogu wypełniania któregokolwiek z pola) i tego typu pole zostanie 'zamaskowane' 11-znakowym ciągiem '*'.

![Logi po implementacji maskowania danych wrażliwych](https://github.com/user-attachments/assets/5aac4cd4-dcf0-4c3b-9729-891c00052342)

W kodzie pliku _models.py_: Zakomentowane linijki zawierają obsługę maskowania pozostałych pól, które w zależności od polityki bezpieczeństwa danych mogłyby ewentualnie również zostać uznane za wrażliwe, bądź nie..

### Zadanie 2

Uruchomienie aplikacji _gitleaks_ komendą `sudo docker run -v /home/eryk/tbo1/task2/:/path zricethezav/gitleaks:latest detect --source="/path" -v` dało następujący rezultat:

`    ○
    │╲
    │ ○
    ○ ░
    ░    gitleaks

Finding:     -----BEGIN RSA PRIVATE KEY-----
MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Qu
KUp...
Secret:      -----BEGIN RSA PRIVATE KEY-----
MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Qu
KUp...
RuleID:      private-key
Entropy:     5.875154
File:        deployment.key
Line:        1
Commit:      bc17b7ddc46f46fff175aed55d68e11bb48166cc
Author:      Grzegorz Siewruk
Email:       gsiewruk@gmail.com
Date:        2023-11-15T12:52:32Z
Fingerprint: bc17b7ddc46f46fff175aed55d68e11bb48166cc:deployment.key:private-key:1

Finding:     -----BEGIN RSA PRIVATE KEY-----
MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Qu
KUp...
Secret:      -----BEGIN RSA PRIVATE KEY-----
MIIBOgIBAAJBAKj34GkxFhD90vcNLYLInFEX6Ppy1tPf9Cnzj4p4WGeKLs1Pt8Qu
KUp...
RuleID:      private-key
Entropy:     5.875154
File:        deployment2.key
Line:        1
Commit:      de9d7b8cb63bd7ae741ec5c9e23891b71709bc28
Author:      Grzegorz Siewruk
Email:       gsiewruk@gmail.com
Date:        2023-11-15T12:49:39Z
Fingerprint: de9d7b8cb63bd7ae741ec5c9e23891b71709bc28:deployment2.key:private-key:1

Finding:     "private_key_id": "002ac3c1623rdewc7bb13f6b10e6"
Secret:      002ac3c1623rdewc7bb13f6b10e6
RuleID:      generic-api-key
Entropy:     3.645593
File:        awscredentials.json
Line:        4
Commit:      bc17b7ddc46f46fff175aed55d68e11bb48166cc
Author:      Grzegorz Siewruk
Email:       gsiewruk@gmail.com
Date:        2023-11-15T12:52:32Z
Fingerprint: bc17b7ddc46f46fff175aed55d68e11bb48166cc:awscredentials.json:generic-api-key:4

Finding:     "private_key": "-----BEGIN PRIVATE KEY-----\nlRsGbRO/1A5LiQHjuR5SASDASDAiSMNeOYqna2R+HEalBoyISASDASD1Tgkj\n4CC02Uux+...\n",
Secret:      -----BEGIN PRIVATE KEY-----\nlRsGbRO/1A5LiQHjuR5SASDASDAiSMNeOYqna2R+HEalBoyISASDASD1Tgkj\n4CC02Uux+...
RuleID:      private-key
Entropy:     5.917361
File:        awscredentials.json
Line:        5
Commit:      bc17b7ddc46f46fff175aed55d68e11bb48166cc
Author:      Grzegorz Siewruk
Email:       gsiewruk@gmail.com
Date:        2023-11-15T12:52:32Z
Fingerprint: bc17b7ddc46f46fff175aed55d68e11bb48166cc:awscredentials.json:private-key:5

1:42PM INF 6 commits scanned.
1:42PM INF scan completed in 18.7s
1:42PM WRN leaks found: 4`

W rezultacie otrzymaliśmy 4 wyniki pozytywne:
- [plik: deployment.key][typ: prywatny klucz RSA][True Positive: Tak] Klucz zaczynający się od '-----BEGIN RSA PRIVATE KEY-----' jest bezpośrednim wskazaniem na prywatny klucz RSA. Plik '.key' nie powinien być zamieszczany w repozytorium. 
- [plik: deployment2.key][typ: prywatny klucz RSA][True Positive: Tak] Klucz zaczynający się od '-----BEGIN RSA PRIVATE KEY-----' jest bezpośrednim wskazaniem na prywatny klucz RSA. Plik '.key' nie powinien być zamieszczany w repozytorium. 
- [plik: awscredentials.json][typ: id klucza prywatnego AWS][True Positive: Nie (zależy od interpretacji)] Jest to identyfikator klucza prywatnego AWS.
- [plik: awscredentials.json][typ: klucz prywatny][True Positive: Tak]Jest to klucz prywatny, prawdopodobnie powiązany z dostępem do usług AWS. 

### Zadanie 3

Uruchomienie weryfikacji pakietów zostało wykonane poleceniem:` sudo docker run -it -v /home/eryk/tbo1/task2/Python/Flask_Book_Library/:/sources pyupio/safety safety check -r /sources/requirements-task.txt --full-report`

Treść raportu:

`+==============================================================================+
|                                                                              |
|                               /$$$$$$            /$$                         |
|                              /$$__  $$          | $$                         |
|           /$$$$$$$  /$$$$$$ | $$  \__//$$$$$$  /$$$$$$   /$$   /$$           |
|          /$$_____/ |____  $$| $$$$   /$$__  $$|_  $$_/  | $$  | $$           |
|         |  $$$$$$   /$$$$$$$| $$_/  | $$$$$$$$  | $$    | $$  | $$           |
|          \____  $$ /$$__  $$| $$    | $$_____/  | $$ /$$| $$  | $$           |
|          /$$$$$$$/|  $$$$$$$| $$    |  $$$$$$$  |  $$$$/|  $$$$$$$           |
|         |_______/  \_______/|__/     \_______/   \___/   \____  $$           |
|                                                          /$$  | $$           |
|                                                         |  $$$$$$/           |
|  by pyup.io                                              \______/            |
|                                                                              |
+==============================================================================+
| REPORT                                                                       |
| checked 18 packages, using free DB (updated once a month)                    |
+============================+===========+==========================+==========+
| package                    | installed | affected                 | ID       |
+============================+===========+==========================+==========+
| jinja2                     | 3.1.2     | <3.1.3                   | 64227    |
+==============================================================================+
| Jinja2 before 3.1.3 is affected by a Cross-Site Scripting vulnerability.     |
| Special placeholders in the template allow writing code similar to Python    |
| syntax. It is possible to inject arbitrary HTML attributes into the rendered |
| HTML template. The Jinja 'xmlattr' filter can be abused to inject arbitrary  |
| HTML attribute keys and values, bypassing the auto escaping mechanism and    |
| potentially leading to XSS. It may also be possible to bypass attribute      |
| validation checks if they are blacklist-based.                               |
+==============================================================================+
| jinja2                     | 3.1.2     | <3.1.4                   | 71591    |
+==============================================================================+
| Jinja is an extensible templating engine. The `xmlattr` filter in affected   |
| versions of Jinja accepts keys containing non-attribute characters. XML/HTML |
| attributes cannot contain spaces, `/`, `>`, or `=`, as each would then be    |
| interpreted as starting a separate attribute. If an application accepts keys |
| (as opposed to only values) as user input, and renders these in pages that   |
| other users see as well, an attacker could use this to inject other          |
| attributes and perform XSS. The fix for CVE-2024-22195 only addressed spaces |
| but not other characters. Accepting keys as user input is now explicitly     |
| considered an unintended use case of the `xmlattr` filter, and code that     |
| does so without otherwise validating the input should be flagged as          |
| insecure, regardless of Jinja version. Accepting _values_ as user input      |
| continues to be safe.                                                        |
+==============================================================================+
| jinja2                     | 3.1.2     | >=0                      | 70612    |
+==============================================================================+
| In Jinja2, the from_string function is prone to Server Side Template         |
| Injection (SSTI) where it takes the source parameter as a template object,   |
| renders it, and then returns it. The attacker can exploit it with INJECTION  |
| COMMANDS in a URI.                                                           |
| NOTE: The maintainer and multiple third parties believe that this            |
| vulnerability isn't valid because users shouldn't use untrusted templates    |
| without sandboxing.                                                          |
+==============================================================================+
| werkzeug                   | 2.3.7     | <2.3.8                   | 62019    |
+==============================================================================+
| Werkzeug 3.0.1 and 2.3.8 include a security fix: Slow multipart parsing for  |
| large parts potentially enabling DoS attacks.                                |
| https://github.com/pallets/werkzeug/commit/b1916c0c083e0be1c9d887ee2f3d69692 |
| 2bfc5c1                                                                      |
+==============================================================================+
| werkzeug                   | 2.3.7     | <3.0.3                   | 71594    |
+==============================================================================+
| Werkzeug is a comprehensive WSGI web application library. The debugger in    |
| affected versions of Werkzeug can allow an attacker to execute code on a     |
| developer's machine under some circumstances. This requires the attacker to  |
| get the developer to interact with a domain and subdomain they control, and  |
| enter the debugger PIN, but if they are successful it allows access to the   |
| debugger even if it is only running on localhost. This also requires the     |
| attacker to guess a URL in the developer's application that will trigger the |
| debugger.                                                                    |
+==============================================================================+
| werkzeug                   | 2.3.7     | <3.0.6                   | 73969    |
+==============================================================================+
| Affected versions of Werkzeug are vulnerable to Path Traversal (CWE-22) on   |
| Windows systems running Python versions below 3.11. The safe_join() function |
| failed to properly detect certain absolute paths on Windows, allowing        |
| attackers to potentially access files outside the intended directory. An     |
| attacker could craft special paths starting with "/" that bypass the         |
| directory restrictions on Windows systems. The vulnerability exists in the   |
| safe_join() function which relied solely on os.path.isabs() for path         |
| validation. This is exploitable on Windows systems by passing paths starting |
| with "/" to safe_join(). To remediate, upgrade to the latest version which   |
| includes additional path validation checks.                                  |
| NOTE: This vulnerability specifically affects Windows systems running Python |
| versions below 3.11 where ntpath.isabs() behavior differs.                   |
+==============================================================================+
| werkzeug                   | 2.3.7     | <3.0.6                   | 73889    |
+==============================================================================+
| Affected versions of Werkzeug are vulnerable to possible resource exhaustion |
| when parsing file data in forms.                                             |
+==============================================================================+
| werkzeug                   | 2.3.7     | <=2.3.7                  | 71595    |
+==============================================================================+
| Werkzeug is a comprehensive WSGI web application library. If an upload of a  |
| file that starts with CR or LF and then is followed by megabytes of data     |
| without these characters: all of these bytes are appended chunk by chunk     |
| into internal bytearray and lookup for boundary is performed on growing      |
| buffer. This allows an attacker to cause a denial of service by sending      |
| crafted multipart data to an endpoint that will parse it. The amount of CPU  |
| time required can block worker processes from handling legitimate requests.  |
+==============================================================================+
| healpy                     | 1.8.0     | <=1.16.6                 | 61774    |
+==============================================================================+
| Healpy 1.16.6 and prior releases ship with a version of 'libcurl' that has a |
| high-severity vulnerability.                                                 |
+==============================================================================+`

Podsumowując raport, odpowiadające podatności do pakietów:
* **jinja2**:
- CVE-2024-22195 (ID: 64227) - CVSS V3 = 6.1 (!) (Base Score)
- CVE-2019-8341 (ID: 70612) - CVSS V3 = 9.8 (!) (Base Score)
- CVE-2024-34064 (ID: 71591) - CVSS V3 = 5.4 (CNA:  GitHub, Inc.)
* **werkzeug**: 
- CVE-2023-46136 (ID: 71595) - CVSS V3 = 7.5 (Base Score)
- CVE-2024-49767 (ID: 73889) - CVSS V3 = 7.5 (Base Score)
- CVE-2024-49766 (ID: 73969) - CVSS V3 = 6.3 (CNA:  GitHub, Inc.)
- CVE-2024-34069 (ID: 71594) - CVSS V3 = 7.5 (CNA:  GitHub, Inc.)
- PVE-2023-62019 (ID: 62019) 
* **healpy**:
- CVE-2023-38545 (ID: 61774) - CVSS V3 = 9.8 (!) (NIST)

Dwie najbardziej krytyczne podatności stwierdzono w pakietach healpy oraz jinja2. Przeanalizujmy podaność dla pakietu jinja2:

W pakiecie wykryto podatność na atak typu Server-Side Template Injection (SSTI) oznaczoną jako Krytyczna. Jest to podatność związana z przetwarzaniem szablonów po stronie serwera. W ataku tym, osoba atakująca wstrzykuje własny kod do szablonu, który jest później renderowany przez serwer. Jeżeli system szablonów nie jest odpowiednio zabezpieczony, złośliwy kod może zostać wykonany na serwerze, co skutkować może atakiem zarówno na serwer i infrastrukturę organizacji, jak i naraża klientów, np. w przypadku osadzenia złośliwych skryptów. 

Wykorzystanie podatności jest możliwe po użyciu metody from_string, ponieważ przyjmuje parametr "source" jako obiekt szablonu, renderuje go, a następnie zwraca wynik. Atakujący może to wykorzystać, wstawiając złośliwe komendy w URI. Właściciel projektu oraz wiele stron trzecich uważa, że ta podatność jest nieuzasadniona, ponieważ użytkownicy nie powinni korzystać z niezaufanych szablonów bez stosowania izolacji (sandboxing). Po analizie w badanej aplikacji tego typu funkcjonalność zdaje się nie być wykorzystywana także prawdopodobieństwo wykorzystania tej podatności jest minimalne, choć niezerowe, dlatego zalecane jest uaktualnienie pakietów wspomnianych przez raport. 


