### PR TITLE
Rafał Wolert - task 2

### DIFF
--- a/Python/Flask_Book_Library/project/customers/models.py
+++ b/Python/Flask_Book_Library/project/customers/models.py
@@ -22,7 +22,7 @@ class Customer(db.Model):
         print("Getting: " + str(self),flush=True)
 
     def __repr__(self):
-        return f"Customer(ID: {self.id}, Name: {self.name}, City: {self.city}, Age: {self.age}, Pesel: {self.pesel}, Street: {self.street}, AppNo: {self.appNo})"
+        return f"Customer(ID: {self.id}, Name: {self.name}, City: {'*' * len(self.city)}, Age: {self.age}, Pesel: {'*' * len(self.pesel)}, Street: {'*' * len(self.street)}, AppNo: {'*' * len(self.appNo)})"
 
 
 with app.app_context():


### PR DESCRIPTION
# Zadanie 1

### Wrażliwe dane w logach aplikacji

Po dodaniu nowego klienta z poziomu endpointu /customers/ w logach aplikacji pojawiają się informacje takie jak adres czy numer PESEL w formie jawnej.

![image](https://github.com/user-attachments/assets/00f0096a-3e31-494d-aad2-93fbaedbc70b)

### Mitygacja

W [commicie](https://github.com/zxcvwrs/task2/commit/eb2d47f6accf7efc01dfede1c9215e13071437c1) zaproponowano rozwiązanie polegające na zamaskowaniu wartości wszystkich pól związanych z adresem oraz pole z numerem PESEL ciągiem ‘*’.

![image 1](https://github.com/user-attachments/assets/69857780-00e4-45e0-a17e-2eea67d41947)

# Zadanie 2

Za pomocą narzędzia gitleaks przeskanowano 7 komitów i pierwotnie wykryto 4 wycieki związane z sekretami. Po weryfikacji, dwa commity (kolor zielony) wskazują na ten sam sekret prywatnego klucza RSA w dwóch plikach. Commit zaznaczony kolorem czerwonym dotyczy również tego samego sekretu zaznaczonego kolorem niebieskim.

![laby-tbo2](https://github.com/user-attachments/assets/919c8f1c-abea-454f-8756-4f6b40aea7cd)


Finalnie, możemy uznać, że wykryto dwa unikalne sekrety w repozytorium.

![image 3](https://github.com/user-attachments/assets/779be778-462e-4e82-9b50-64425d52fbd0)

_Ten sam klucz RSA w dwóch plikach (usunięcie słowa RSA zmienia identyfikację z klucza RSA na PKCS8INF wg. openssl - nie zostało to uwzględnione w użyciu narzędzia gitleaks)._

# Zadanie 3

Za pomocą narzędzia pyupio zweryfikowanio pakiety, z których trzy zawierały podatności. Wybrano pakiet healpy, w którym zidentyfikowano podatność w bibliotece healpy ≤1.16.6. 

![image 4](https://github.com/user-attachments/assets/d05f8263-878f-4ca9-88d4-8d2994e9b34a)


Wg. strony: https://data.safetycli.com/packages/pypi/healpy/vulnerabilities podatność określana jest numerem CVE-2023-38545. Wg. katalogu NIST https://nvd.nist.gov/vuln/detail/CVE-2023-38545 podatność ma severity 9.8 CRITICAL i polega na przepełnieniu bufora na stercie przy rozwiązywaniu zbyt długich nazw hostów (ponad 255 bajtów) przy użyciu proxy SOCKS5. 

### Analiza możliwości wykorzystania

W pliku Dockerfile znajdujemy faktyczny plik requirements.txt używany do instalacji pakietów aplikacji.

```python
# Instalujemy zależności
RUN pip install --no-cache-dir -r requirements.txt
```

W zawartości pliku requirements.txt nie znajdujemy informacji o pakiecie healpy - znajduje się on w niewykorzystywanym pliku requirements-task.txt w podatnej wersji 1.8.0. W związku z tym uznaje się, że podatność nie może być bezpośrednio wykorzystana, dla porządku zaleca się usunięcie pliku requirements-task.txt z repozytorium.