### PR TITLE
Lab 2: Logowanie oraz biblioteki OpenSource

### DIFF
--- a/Java/spring-thymeleaf-crud-example/src/main/java/com/example/thymeleaf/entity/Address.java
+++ b/Java/spring-thymeleaf-crud-example/src/main/java/com/example/thymeleaf/entity/Address.java
@@ -3,12 +3,12 @@ package com.example.thymeleaf.entity;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.UUID;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Getter
 @Setter
@@ -58,14 +58,21 @@ public class Address {
         return "Address{" +
                 "id='" + id + '\'' +
                 ", zipCode='" + zipCode + '\'' +
-                ", street='" + street + '\'' +
-                ", number='" + number + '\'' +
-                ", complement='" + complement + '\'' +
-                ", district='" + district + '\'' +
+                ", street='" + maskSensitiveData(street) + '\'' +
+                ", number='" + maskSensitiveData(number) + '\'' +
+                ", complement='" + maskSensitiveData(complement) + '\'' +
+                ", district='" + maskSensitiveData(district) + '\'' +
                 ", city='" + city + '\'' +
                 ", state='" + state + '\'' +
                 ", createdAt=" + createdAt +
                 ", updatedAt=" + updatedAt +
                 '}';
+    }
+
+    private String maskSensitiveData(String sensitiveData) {
+        if (sensitiveData == null || sensitiveData.isEmpty()) {
+            return sensitiveData;
+        }
+        return "*".repeat(sensitiveData.length());
     }
 }


### PR DESCRIPTION
### Zadanie 1 - Weryfikacja wycieku wrażliwych danych

W aplikacji Java znaleziono wyciek wrażliwych danych w logach podczas dodawania nowego studenta:

<img width="1420" alt="sensitive-data" src="https://github.com/user-attachments/assets/998bb9b5-4ee3-4bdf-a821-c64652ea975e">

Zaproponowana poprawka skutecznie maskuje wrażliwe dane (street, number, complement, district) w logach.

### Zadanie 2 - weryfikacja wycieku sekretów
Aplikacja gitleaks znalazła 4 sekrety, które zostały zapisane w kodzie źródłowym:
![gitleaks](https://github.com/user-attachments/assets/9d0c1d12-478e-4eb9-84d1-0416298c722f)
Wszystkie wykrycie są prawidłowe, to znaczy nie występuję ani jedno wykrycie fałszywie pozytywne, a więc rzeczywiście doszło do wycieku kluczy.

### Zadanie 3 - weryfikacja bezpieczeństwa bibliotek OpenSource wykorzystywanych w projekcie
Uruchomiona została weryfikacja pakietów OpenSource aplikacji Python:
![wynik-weryfikacji-pakietow](https://github.com/user-attachments/assets/0c809ccf-b66d-4676-bc51-ddc09597e28d)
Podatność o najwyższej krytyczności według CVSS 3 (Base Score: 9.8 CRITICAL) posiada id: 70612 i CVE-2019-8341. W pakiecie Jinja2 wykryto podatność Sever-Side Template Injection (SSSTI) w funkcji from_string. Funkcja ta pozwala na renderowanie szablonu z przekazanego tekstu, jeśli użytkownik nie zweryfikuje przekazanego tekstu, atakujący może wstrzyknąć do niego kod wykonujący polecenia systemowe. Twórcy biblioteki Jinja2 uważają, że nie jest to podatność, a błędne korzystanie z funkcji przez użytkowników, ponieważ dane wejściowe w szablonach zawsze powinny pochodzić z zaufanych źródeł i być weryfikowane. Wykorzystanie tej podatności w tej aplikacji jest niemożliwe, ponieważ w całym projekcie nie jest wykorzystywana funkcja from_string z biblioteki Jinja2.