### PR TITLE
Lab 2 - Security By Design

### DIFF
--- a/Python/Flask_Book_Library/project/customers/models.py
+++ b/Python/Flask_Book_Library/project/customers/models.py
@@ -22,8 +22,15 @@ class Customer(db.Model):
         print("Getting: " + str(self),flush=True)
 
     def __repr__(self):
-        return f"Customer(ID: {self.id}, Name: {self.name}, City: {self.city}, Age: {self.age}, Pesel: {self.pesel}, Street: {self.street}, AppNo: {self.appNo})"
+        return f"Customer(ID: {self.id}, Name: {self.name}, City: {mask_data(self.city, 1)}, Age: {self.age}, Pesel: {mask_data(self.pesel)}, Street: {mask_data(self.street, 1)}, AppNo: {mask_data(self.appNo)})"
 
+def mask_data(data, visible_start=0, mask_char="*"):
+    if isinstance(data, int):
+        return (mask_char * 3)
+    elif isinstance(data, str):
+        masked_length = max(0, len(data) - visible_start)
+        return data[:visible_start] + (mask_char * masked_length)
+    return "N/A"
 
 with app.app_context():
     db.create_all()


### PR DESCRIPTION
# Zadanie 1

Wybrane rozwiązanie: Python

Wyciek wrażliwych danych występuje w przypadku dodawania nowego klienta. Chodzi głownie o numer PESEL oraz adres zamieszkania, którą też można w pewnym scenariuszach uznać za danę wrażliwą.


![image-1](https://github.com/user-attachments/assets/95b7857f-8cfc-4aeb-b2a1-b7127fdbd5c7)

W ramach poprawki tego problemu dodałem funkcję, która pozwala ukrywać wrażliwe dane, została użyta w przypadku numeru PESEL, miasta, ulicy oraz numeru apartamentu. Poniżej przykład.

![image](https://github.com/user-attachments/assets/494bb7d2-d913-4ea1-be65-7d47430893ba)

# Zadanie 2

Gitleaks udało się wykryć 4 wycieki sekretów. Wszystkie z nich były true-positive, czyli dotyczyły rzeczywistych wycieków sekretów w poprzednich commitach. Widać, że autor w między czasie się zreflektował i usunał klucze z repozytorium niestety ślad po tym nadal się znajduje. Wycieku dotyczyły klucze prywatne i id klucza prywatnego. 
Wycieki nastapiły w plikach `awscredentials.json`, `deployment.key` i `deployment2.key`.

![image-2](https://github.com/user-attachments/assets/775feeeb-4638-4f12-a0ed-255d6a3c2e84)

# Zadanie 3
Narzedzie safety wykryło w sumie 3 pakiety, które zawierają łącznie 9 podatności.

![image-3](https://github.com/user-attachments/assets/cd510211-93ab-4b18-99e7-c81ec6bef1db)

#### Analiza możliwości wykorzystania
Wybrana podatność: CVE-2023-38545

Pakiet `healpy` w wersji <= `1.16.6` wewnątrz wykorzystuje bibliotekę `libcurl` z podatnością `CVE-2023-38545` o wskaźniku krytyczności 9.8. Podatność przejawia się przepełnieniem buffora na stercie w przypadku wykorzystania SOCKS5 proxy i przekazaniu zbyt długiego (więcej niż 255 bajtów) nazwy hosta. Aby wykorzystać tę podatność musi dojść do wolnego handshake SOCKS5, klient musi wykorzystywać hostname dłuższy niż pobierany buffer i atakujący musi przekazać spreparowany URL. 


