### PR TITLE
Realizacja zadania 2

### DIFF
--- a/Python/Flask_Book_Library/project/customers/models.py
+++ b/Python/Flask_Book_Library/project/customers/models.py
@@ -21,6 +21,7 @@ class Customer(db.Model):
         self.appNo = appNo
         print("Getting: " + str(self),flush=True)
 
+    @staticmethod
     def mask(data: str):
         return len(data) * "*"
 

--- a/Python/Flask_Book_Library/project/customers/models.py
+++ b/Python/Flask_Book_Library/project/customers/models.py
@@ -21,8 +21,11 @@ class Customer(db.Model):
         self.appNo = appNo
         print("Getting: " + str(self),flush=True)
 
+    def mask(data: str):
+        return len(data) * "*"
+
     def __repr__(self):
-        return f"Customer(ID: {self.id}, Name: {self.name}, City: {self.city}, Age: {self.age}, Pesel: {self.pesel}, Street: {self.street}, AppNo: {self.appNo})"
+        return f"Customer(ID: {self.id}, Name: {self.name}, City: {self.mask(self.city)}, Age: {self.age}, Pesel: {self.mask(self.pesel)}, Street: {self.mask(self.street)}, AppNo: {self.mask(self.appNo)})"
 
 
 with app.app_context():


### PR DESCRIPTION
# Zadanie 1

Podczas tworzenia klienta w logach pojawiają się informacje na temat wszystkich jego danych

```
Getting: Customer(ID: None, Name: Jan Nowak, City: Warsaw, Age: 12, Pesel: 1234567891234, Street: ulica, AppNo: 2)
```

Wprowadzono poprawkę w `/task2/Python/Flask_Book_Library/project/customers/models.py` maskując wrażliwe dane dotyczące adresu oraz numeru pesel.

```
Getting: Customer(ID: None, Name: Jan Nowak, City: ******, Age: 12, Pesel: *************, Street: *****, AppNo: *)
```

# Zadanie 2

Po uruchomieniu gitleaks znalezione zostały 3 klucze prywatne dostępne w poniższych linkach:

```
https://github.com/twezowic/task2/blob/bc17b7ddc46f46fff175aed55d68e11bb48166cc/awscredentials.json#L5

https://github.com/twezowic/task2/blob/de9d7b8cb63bd7ae741ec5c9e23891b71709bc28/deployment2.key#L1

https://github.com/twezowic/task2/blob/bc17b7ddc46f46fff175aed55d68e11bb48166cc/deployment.key#L1
```

Nazwy oraz sama zawartość wskazuje na to że nie były to przypadki wykrycia fałszywie pozytwnego, a rzeczywiste sekrety z czego pierwszy dotyczył chmury AWS.

Klucze zostały usunięty w commicie

```
https://github.com/twezowic/task2/commit/fd6740006a794a1a8bb0cd7d8a2a6ee95d8cbec3
```

Git pozwala jednak na dostęp do historii i dalszego ich uzyskania.

# Zadanie 3

W wyniki analizy sprawdzone zostało 18 pakietów. Z czego 3 z nich są podatne w wersjach wykorzystywanych w aplikacji:

```
jinja2
werkzeug
healpy
```

W pakiecie werkzeug (zainstalowana wersja 2.3.7) wykryto podatność o najwyższym poziomie severity 7.5 (https://github.com/advisories/GHSA-2g68-c3qc-8985)

```
+==============================================================================+
| werkzeug | 2.3.7 | <3.0.3 | 71594 |
+==============================================================================+
| Werkzeug is a comprehensive WSGI web application library. The debugger in |
| affected versions of Werkzeug can allow an attacker to execute code on a |
| developer's machine under some circumstances. This requires the attacker to |
| get the developer to interact with a domain and subdomain they control, and |
| enter the debugger PIN, but if they are successful it allows access to the |
| debugger even if it is only running on localhost. This also requires the |
| attacker to guess a URL in the developer's application that will trigger the |
| debugger. |
+==============================================================================+
```

Podatność ta dotyczy klasy werkzeug.debug.DebuggedApplication i umożliwia wykonanie dowolnego kodu (RCE) na komputerze programisty, jeśli aplikacja działa w trybie debugowania. Wymaga to od programisty wejścia na złośliwą stronę i wpisania PIN-u, co skutkuje wykonaniem dowolnego kodu (RCE) na maszynie lokalnej. Po analizie w badanej aplikacji klasa ta nie jest wykorzystywana także prawdopodobieństwo wykorzystania tej podatności jest minimalne.
