### PR TITLE
Lab 2 Marta Sobol

### DIFF
--- a/Python/Flask_Book_Library/project/customers/models.py
+++ b/Python/Flask_Book_Library/project/customers/models.py
@@ -22,7 +22,10 @@ class Customer(db.Model):
         print("Getting: " + str(self),flush=True)
 
     def __repr__(self):
-        return f"Customer(ID: {self.id}, Name: {self.name}, City: {self.city}, Age: {self.age}, Pesel: {self.pesel}, Street: {self.street}, AppNo: {self.appNo})"
+        return f"Customer(ID: {self.id}, Name: {self.name}, City: {self.city}, Age: {self.age}, Pesel: {self._mask_data(self.pesel)}, Street: {self._mask_data(self.street)}, AppNo: {self._mask_data(self.appNo)})"
+
+    def _mask_data(self, data):
+        return len(data) * "*"
 
 
 with app.app_context():


### PR DESCRIPTION
# Zadanie 1
Podczas dodawania nowego klienta w logach aplikacji wyświetlane są jego wrażliwe dane np. pesel, adres zamieszkania.
<img width="1318" height="316" alt="Zrzut ekranu 2025-11-25 004135" src="https://github.com/user-attachments/assets/df85a503-f4c8-476d-9281-de3ffcd20ab9" />
## Poprawka
Dodałam maskowanie danych wrażliwych, ich wartości zamieniłam na znak *.
<img width="1315" height="75" alt="Zrzut ekranu 2025-11-25 005636" src="https://github.com/user-attachments/assets/5b730a72-4a49-4837-9d72-447a51b528dd" />

# Zadanie 2
Gitleaks wykrył 3 wycieki w repozytorium
<img width="1329" height="561" alt="Zrzut ekranu 2025-11-25 010403" src="https://github.com/user-attachments/assets/8434b95c-2fac-42f4-af6c-8cceb8bc5519" />
<img width="1305" height="560" alt="Zrzut ekranu 2025-11-25 010420" src="https://github.com/user-attachments/assets/09653e7c-bfc6-4714-8080-09cebb29d326" />
<img width="1323" height="496" alt="Zrzut ekranu 2025-11-25 010433" src="https://github.com/user-attachments/assets/a1820bac-ece2-4c8c-a741-6090e7070fad" />
Wszystkie wskazane wycieki są prawdziwe, nie ma tutaj false positive.

# Zadanie 3
Znaleziono podatności w bibliotekach jinja2 x5, werkzeug x5, healpy
## Wybrana podatność werkzeug
```
+==============================================================================+
| werkzeug                   | 2.3.7     | <3.0.3                   | 71594    |
+==============================================================================+
| Werkzeug is a comprehensive WSGI web application library. The debugger in    |
| affected versions of Werkzeug can allow an attacker to execute code on a     |
| developer's machine under some circumstances. This requires the attacker to  |
| get the developer to interact with a domain and subdomain they control, and  |
| enter the debugger PIN, but if they are successful it allows access to the   |
| debugger even if it is only running on localhost. This also requires the     |
| attacker to guess a URL in the developer's application that will trigger the |
| debugger.                                                                    
```
Wykryto błąd związany z debuggerem werkzeug, który w określonych warunkach może umożliwić zdalne wykonanie kodu (RCE) na komputerze developera.
Wykorzystanie podatności możliwe jest gdy:
1. Aplikacja musi być uruchomiona w trybie **debug**.
2. Developer musi **odwiedzić złośliwą stronę** kontrolowaną przez atakującego.
3. Atakujący musi **znać lub zgadnąć endpoint**, który wywoła wyjątek i aktywuje debugger.
4. Developer musi **wprowadzić PIN debuggera** przechwycony przez atakującego.

Aplikacja uruchamiana jest w trybie debug
```
if __name__ == '__main__':
    app.run(debug=True)
```
Jest to podatność związana z środowiskiem developerskim, w produkcji tryb debug powinien zostać wyłączony. Jeżeli wyłączymy tryb debug ta podatność znika, ale nadal paczka wekzeug powinna zostać zaktualizowana do nowszej wersji gdzie usunięto tą podatność.